### PR TITLE
Fix mutation issues

### DIFF
--- a/src/blocksToNodes.js
+++ b/src/blocksToNodes.js
@@ -8,18 +8,11 @@ const optionProps = ['projectId', 'dataset', 'imageOptions']
 const isDefined = val => typeof val !== 'undefined'
 const defaults = {imageOptions: {}}
 
-function quickFixDeepClone(value) {
-  return JSON.parse(JSON.stringify(value))
-}
-
 function blocksToNodes(h, properties) {
   const {defaultSerializers, serializeSpan} = getSerializers(h)
 
   const props = objectAssign({}, defaults, properties)
-  const blocks = nestLists(
-    // Todo: fix mutation of blocks properly
-    quickFixDeepClone(Array.isArray(props.blocks) ? props.blocks : [props.blocks])
-  )
+  const blocks = nestLists(Array.isArray(props.blocks) ? props.blocks : [props.blocks])
   const serializers = mergeSerializers(defaultSerializers, props.serializers || {})
   const options = optionProps.reduce((opts, key) => {
     const value = props[key]

--- a/src/buildMarksTree.js
+++ b/src/buildMarksTree.js
@@ -92,7 +92,9 @@ function sortMarksByOccurences(span, i, spans) {
   }, {})
 
   const sortByOccurence = sortMarks.bind(null, markOccurences)
-  return span.marks.sort(sortByOccurence)
+
+  // Slicing because sort() mutates the input
+  return span.marks.slice().sort(sortByOccurence)
 }
 
 function sortMarks(occurences, markA, markB) {

--- a/src/nestLists.js
+++ b/src/nestLists.js
@@ -27,7 +27,23 @@ function nestLists(blocks) {
     // Different list props, are we going deeper?
     if (block.level > currentList.level) {
       const newList = listFromBlock(block)
-      lastChild(currentList).children.push(newList)
+
+      // Because HTML is kinda weird, nested lists needs to be nested within list items
+      // So while you would think that we could populate the parent list with a new sub-list,
+      // We actually have to target the last list element (child) of the parent.
+      // However, at this point we need to be very careful - simply pushing to the list of children
+      // will mutate the input, and we don't want to blindly clone the entire tree.
+
+      // Clone the last child while adding our new list as the last child of it
+      const lastListItem = lastChild(currentList)
+      const newLastChild = Object.assign({}, lastListItem, {
+        children: lastListItem.children.concat(newList)
+      })
+
+      // Swap the last child
+      currentList.children[currentList.children.length - 1] = newLastChild
+
+      // Set the newly created, deeper list as the current
       currentList = newList
       continue
     }

--- a/src/nestLists.js
+++ b/src/nestLists.js
@@ -1,3 +1,5 @@
+const objectAssign = require('object-assign')
+
 /* eslint-disable max-depth, complexity */
 function nestLists(blocks) {
   const tree = []
@@ -36,7 +38,7 @@ function nestLists(blocks) {
 
       // Clone the last child while adding our new list as the last child of it
       const lastListItem = lastChild(currentList)
-      const newLastChild = Object.assign({}, lastListItem, {
+      const newLastChild = objectAssign({}, lastListItem, {
         children: lastListItem.children.concat(newList)
       })
 


### PR DESCRIPTION
Tracked down the mutations that were happening:

- Marks were being sorted, but I had forgotten that `sort()` mutates the array instead of cloning it
- When going deeper into lists, we were appending the deeper list to the last child of the parent list (because `ul > li > ul` in html), but I had overlooked that we were appending to a list *item*, not the actual *list*. Lists are cloned, since we create a virtual node for them, but list items are kept as-is.

This PR fixes these issues and removes the quickfix.
