### PR TITLE
Pre-requisite for block-content-to-react#6

### DIFF
--- a/src/blocksToNodes.js
+++ b/src/blocksToNodes.js
@@ -2,7 +2,6 @@ const objectAssign = require('object-assign')
 const buildMarksTree = require('./buildMarksTree')
 const nestLists = require('./nestLists')
 const generateKeys = require('./generateKeys')
-const getSerializers = require('./serializers')
 const mergeSerializers = require('./mergeSerializers')
 
 // Properties to extract from props and pass to serializers as options
@@ -10,8 +9,7 @@ const optionProps = ['projectId', 'dataset', 'imageOptions']
 const isDefined = val => typeof val !== 'undefined'
 const defaults = {imageOptions: {}}
 
-function blocksToNodes(h, properties) {
-  const {defaultSerializers, serializeSpan} = getSerializers(h)
+function blocksToNodes(h, properties, defaultSerializers, serializeSpan) {
 
   const props = objectAssign({}, defaults, properties)
   const rawBlocks = Array.isArray(props.blocks) ? props.blocks : [props.blocks]

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,11 @@ const renderNode = (serializer, properties, children) => {
   return hyperscript(tag, props, childNodes)
 }
 
-const {defaultSerializers} = getSerializers(renderNode)
-const blockContentToHyperscript = blocksToNodes.bind(null, renderNode)
+const {defaultSerializers, serializeSpan} = getSerializers(renderNode)
+
+const blockContentToHyperscript = options => {
+  return blocksToNodes(renderNode, options, defaultSerializers, serializeSpan)
+}
 
 // Expose default serializers to the user
 blockContentToHyperscript.defaultSerializers = defaultSerializers

--- a/test/blocksToHyperScript.test.js
+++ b/test/blocksToHyperScript.test.js
@@ -1,11 +1,9 @@
 /* eslint-disable id-length, max-len */
 const runTests = require('@sanity/block-content-tests')
 const blocksToHyperScript = require('../src')
-const getSerializers = require('../src/serializers')
 
 const h = blocksToHyperScript.renderNode
 const getImageUrl = blocksToHyperScript.getImageUrl
-const {defaultSerializers, serializeSpan} = getSerializers(h)
 const normalize = html =>
   html
     .replace(/<br(.*?)\/>/g, '<br$1>')
@@ -20,8 +18,8 @@ const normalize = html =>
     })
 
 const render = options => {
-  const rootNode = blocksToHyperScript(options, defaultSerializers, serializeSpan)
+  const rootNode = blocksToHyperScript(options)
   return rootNode.outerHTML || rootNode
 }
 
-runTests({render, h, normalize, getImageUrl, defaultSerializers, serializeSpan})
+runTests({render, h, normalize, getImageUrl})

--- a/test/blocksToHyperScript.test.js
+++ b/test/blocksToHyperScript.test.js
@@ -1,9 +1,11 @@
 /* eslint-disable id-length, max-len */
 const runTests = require('@sanity/block-content-tests')
 const blocksToHyperScript = require('../src')
+const getSerializers = require('../src/serializers')
 
 const h = blocksToHyperScript.renderNode
 const getImageUrl = blocksToHyperScript.getImageUrl
+const {defaultSerializers, serializeSpan} = getSerializers(h)
 const normalize = html =>
   html
     .replace(/<br(.*?)\/>/g, '<br$1>')
@@ -18,8 +20,8 @@ const normalize = html =>
     })
 
 const render = options => {
-  const rootNode = blocksToHyperScript(options)
+  const rootNode = blocksToHyperScript(options, defaultSerializers, serializeSpan)
   return rootNode.outerHTML || rootNode
 }
 
-runTests({render, h, normalize, getImageUrl})
+runTests({render, h, normalize, getImageUrl, defaultSerializers, serializeSpan})


### PR DESCRIPTION
Moving serializer instantiation out of blocksToNodes.

Note: Requires Requires https://github.com/sanity-io/block-content-to-react/pull/8