### PR TITLE
Treat span with 'text', but a missing/undefined 'marks' as a text span

### DIFF
--- a/src/buildMarksTree.js
+++ b/src/buildMarksTree.js
@@ -129,7 +129,7 @@ function sortMarks(occurences, markA, markB) {
 }
 
 function isTextSpan(node) {
-  return typeof node.text === 'string' && Array.isArray(node.marks)
+  return typeof node.text === 'string' && (Array.isArray(node.marks) || typeof node.marks === 'undefined')
 }
 
 function findLastParentNode(nodes) {

--- a/test/blocksToHyperScript.test.js
+++ b/test/blocksToHyperScript.test.js
@@ -91,4 +91,22 @@ describe('internals', () => {
       })
     }).toThrow(/block-content-image-materializing/)
   })
+
+  test('treats text spans without marks as text spans', () => {
+    expect(
+      render({
+        blocks: [
+          {
+            _type: 'block',
+            children: [
+              {
+                _type: 'span',
+                text: 'Rush'
+              }
+            ]
+          }
+        ]
+      })
+    ).toEqual('<p>Rush</p>')
+  })
 })


### PR DESCRIPTION
As originally reported by @mmgj on Gitter, the following code would throw an error:

```js
const blockContentToHyperscript = require('@sanity/block-content-to-hyperscript')
blockContentToHyperscript({
  blocks: [
    {
      _key: 'P8F7ONes',
      _type: 'block',
      children: [
        {
          _key: 'ZG0Tz6QB',
          _type: 'span',
          text: 'Rush'
        }
      ]
    }
  ]
})
```
This was caused by the `buildMarksTree()` treating the span node above as a non-text node. 
If the span had an an empty array for `marks`, it would work just fine. Seems to me like a missing/undefined `marks` property should be treated the same way as an empty marks array, so I changed the `isTextSpan()` function to also check for a missing/undefined `node.marks`. Let me know if any of my assumptions are wrong or you think it should be solved differently.