### PR TITLE
Option to ignore uknown block types with overridable serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ client.fetch('*[_type == "article"][0]').then(article => {
 * `serializers.listItem` - Function to use when rendering a list item node
 * `serializers.hardBreak` - Function to use when transforming newline characters to a hard break (default: `<br/>`, pass `false` to render newline character)
 * `serializers.container` - Serializer for the container wrapping the blocks
+* `serializers.unknownType` - Override the default serializer for for blocks of unknown type, if `ignoreUnknownTypes` is set to `true`.
 * `imageOptions` - When encountering image blocks, this defines which query parameters to apply in order to control size/crop mode etc.
+* `ignoreUnknownTypes` - If set to true, don't error on unkown block types, but output an hidden div instead with a warning. The default output can be overridden with `serializers.unknownType`
 
 In addition, in order to render images without materializing the asset documents, you should also specify:
 

--- a/src/blocksToNodes.js
+++ b/src/blocksToNodes.js
@@ -5,9 +5,9 @@ const generateKeys = require('./generateKeys')
 const mergeSerializers = require('./mergeSerializers')
 
 // Properties to extract from props and pass to serializers as options
-const optionProps = ['projectId', 'dataset', 'imageOptions']
+const optionProps = ['projectId', 'dataset', 'imageOptions', 'ignoreUnknownTypes']
 const isDefined = val => typeof val !== 'undefined'
-const defaults = {imageOptions: {}}
+const defaults = {imageOptions: {}, ignoreUnknownTypes: false}
 
 function blocksToNodes(h, properties, defaultSerializers, serializeSpan) {
   const props = objectAssign({}, defaults, properties)

--- a/src/serializers.js
+++ b/src/serializers.js
@@ -10,6 +10,13 @@ module.exports = (h, serializerOpts) => {
     const blockType = node._type
     const serializer = serializers.types[blockType]
     if (!serializer) {
+      if (options.ignoreUnknownTypes) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Unknown block type "${blockType}", please specify a serializer for it in the \`serializers.types\` prop`
+        )
+        return h(serializers.unknownType, {node, options, isInline}, children)
+      }
       throw new Error(
         `Unknown block type "${blockType}", please specify a serializer for it in the \`serializers.types\` prop`
       )
@@ -53,6 +60,11 @@ module.exports = (h, serializerOpts) => {
 
     return h('li', null, children)
   }
+
+    // Unknown type default serializer
+    function DefaultUknownTypeSerializer(props) {
+      return h('div', {style: {display: 'none'}}, `Unknown block type "${props.node._type}", please specify a serializer for it in the \`serializers.types\` prop`)
+    }
 
   // Renderer of an actual block of type `block`. Confusing, we know.
   function BlockTypeSerializer(props) {
@@ -151,6 +163,7 @@ module.exports = (h, serializerOpts) => {
     block: BlockSerializer,
     span: SpanSerializer,
     hardBreak: HardBreakSerializer,
+    unknownType: DefaultUknownTypeSerializer,
 
     // Container element
     container: 'div',

--- a/test/blocksToHyperScript.test.js
+++ b/test/blocksToHyperScript.test.js
@@ -109,4 +109,53 @@ describe('internals', () => {
       })
     ).toEqual('<p>Rush</p>')
   })
+
+  test('should error on unknown types if ignoreUnknownTypes is not set', () => {
+    expect(() =>
+      render({
+        blocks: [
+          {
+            _type: 'someUnknownType',
+            someProp: true
+          }
+        ]
+      })
+    ).toThrow(
+      new Error(
+        'Unknown block type "someUnknownType", please specify a serializer for it in the `serializers.types` prop'
+      )
+    )
+  })
+
+  test('should not error on unknown types if ignoreUnknownTypes is set', () => {
+    const fn = () =>
+      render({
+        ignoreUnknownTypes: true,
+        blocks: [
+          {
+            _type: 'someUnknownType',
+            someProp: true
+          }
+        ]
+      })
+    expect(fn()).toEqual("<div style=\"display: none;\">Unknown block type \"someUnknownType\", please specify a serializer for it in the `serializers.types` prop</div>")
+  })
+
+  test('should output a custom rendering for unknown types if unknownType serializer given, and ignoreUnknownTypes is set', () => {
+    const fn = () =>
+      render({
+        ignoreUnknownTypes: true,
+        serializers: {
+          unknownType: props => h('div', {style: {color: 'red'}}, `Don't know what to do with '${props.node._type}'`)
+        },
+        blocks: [
+          {
+            _type: 'someUnknownType',
+            someProp: true
+          }
+        ]
+      })
+    expect(fn()).toEqual("<div style=\"color: red;\">Don't know what to do with 'someUnknownType'</div>")
+  })
+
 })


### PR DESCRIPTION
It's a common issue that unknown block types breaks the frontend. This makes it fail safe (if you want).

It can be discussed if marks should follow the same pattern, or we should just do as we do today (output a span for them with a console warn).