### PR TITLE
Serialize sup/sub HTML tags as marks by default

### DIFF
--- a/src/serializers.js
+++ b/src/serializers.js
@@ -128,6 +128,8 @@ module.exports = (h, serializerOpts) => {
 
   const HardBreakSerializer = () => h('br')
   const defaultMarkSerializers = {
+    sub: RawMarkSerializer.bind(null, 'sub'),
+    sup: RawMarkSerializer.bind(null, 'sup'),
     strong: RawMarkSerializer.bind(null, 'strong'),
     em: RawMarkSerializer.bind(null, 'em'),
     code: RawMarkSerializer.bind(null, 'code'),


### PR DESCRIPTION
There are probably several HTML tags that could do the same, but in this PR I added only sub and sup.

Ref:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup