### PR TITLE
feat: add config option for opting out of wrapper container

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ client.fetch('*[_type == "article"][0]').then(article => {
 ## Options
 
 - `className` - When more than one block is given, a container node has to be created. Passing a `className` will pass it on to the container. Note: see `renderContainerOnSingleChild`.
+- `renderContainer` - Pass `false` if you do not wish to have the content wrapped in a containing element (default div). Default `true`.
 - `renderContainerOnSingleChild` - When a single block is given as input, the default behavior is to not render any container. If you always want to render the container, pass `true`.
 - `serializers` - Specifies the functions to use for rendering content. Merged with default serializers.
 - `serializers.types` - Serializers for block types, see example above

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,11 @@ const renderNode = (serializer, properties, children) => {
 const {defaultSerializers, serializeSpan} = getSerializers(renderNode, {useDashedStyles: true})
 
 const blockContentToHyperscript = options => {
-  return blocksToNodes(renderNode, options, defaultSerializers, serializeSpan)
+  const nodes = blocksToNodes(renderNode, options, defaultSerializers, serializeSpan)
+  if (options.renderContainer === false) {
+    return nodes.innerHTML
+  }
+  return nodes
 }
 
 // Expose default serializers to the user

--- a/test/blocksToHyperScript.test.js
+++ b/test/blocksToHyperScript.test.js
@@ -159,6 +159,42 @@ describe('internals', () => {
     )
   })
 
+  test('can configure no container wrapper', () => {
+    const blocks = [
+      {
+        _type: 'block',
+        markDefs: [],
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            marks: [],
+            text: 'Hello'
+          }
+        ]
+      },
+      {
+        _type: 'block',
+        markDefs: [],
+        style: 'normal',
+        children: [
+          {
+            _type: 'span',
+            marks: [],
+            text: 'There'
+          }
+        ]
+      }
+    ]
+
+    const fn = () =>
+      blocksToHyperScript({
+        blocks,
+        renderContainer: false
+      })
+    expect(fn()).toEqual('<p>Hello</p><p>There</p>')
+  })
+
   test('should output a custom rendering for unknown types if unknownType serializer given, and ignoreUnknownTypes is set', () => {
     const fn = () =>
       render({


### PR DESCRIPTION
Adds `renderContainer` option which defaults to `true` and the current behaviour. If set to `false` we simply return the `innerHTML` of the normal rendering, thus avoiding the wrapping element. This was deemed to be the least intrusive way to achieve this feature.

Unsure, however,  if it is okay for this module to return a string versus a node with children. But the frequent usage of `rootNode.outerHTML || rootNode` in both this test suite and in downstream modules indicate that the contract is not all that clear to begin with.